### PR TITLE
Fix HTTPS support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+t.b.d.
+ o Fix HTTPS support with newer LWP versions
+
 Mon Feb 18 2013 Michael South <msouth@cpan.org>
  o CPAN Release 2.61
 

--- a/lib/LWP/Parallel/Protocol/http.pm
+++ b/lib/LWP/Parallel/Protocol/http.pm
@@ -17,8 +17,8 @@ use Carp ();
 use vars qw(@ISA @EXTRA_SOCK_OPTS);
 
 require LWP::Parallel::Protocol;
-require LWP::Protocol::http10; # until i figure out gisle's http1.1 stuff!
-@ISA = qw(LWP::Parallel::Protocol LWP::Protocol::http10);
+require LWP::Protocol::http; # until i figure out gisle's http1.1 stuff!
+@ISA = qw(LWP::Parallel::Protocol LWP::Protocol::http);
 
 my $CRLF         = "\015\012";     # how lines should be terminated;
 				   # "\r\n" is not correct on all systems, for

--- a/lib/LWP/Parallel/Protocol/https.pm
+++ b/lib/LWP/Parallel/Protocol/https.pm
@@ -23,7 +23,11 @@ if ($IO::Socket::SSL::VERSION) {
 use vars qw(@ISA);
 
 require LWP::Parallel::Protocol::http;
-require LWP::Protocol::https10;
-@ISA=qw(LWP::Protocol::https10 LWP::Parallel::Protocol::http);
+require LWP::Protocol::https;
+@ISA=qw(LWP::Protocol::https LWP::Parallel::Protocol::http);
+
+package LWP::Parallel::Protocol::https::Socket;
+
+our @ISA = qw(LWP::Protocol::https::Socket);
 
 1;

--- a/t/live/http_https.t
+++ b/t/live/http_https.t
@@ -1,0 +1,19 @@
+print "1..2\n";
+
+use strict;
+use LWP::Parallel::UserAgent;
+
+my $ua = LWP::Parallel::UserAgent->new(keep_alive => 1);
+
+my $http_req = HTTP::Request->new(GET => "http://www.w3.org/");
+my $https_req = HTTP::Request->new(GET => "https://www.w3.org/");
+
+my $result_http;
+my $result_https;
+$ua->register($http_req, sub { $result_http = $_[2]->{scheme} eq 'http' and $_[1]->is_success; });
+$ua->register($https_req, sub {	$result_https = $_[2]->{scheme} eq 'https' and $_[1]->is_success; });
+
+$ua->wait(30);
+
+print ''.($result_http ? '' : 'not ')."ok 1 HTTP\n";
+print ''.($result_https ? '' : 'not ')."ok 2 HTTPS\n";


### PR DESCRIPTION
ParallelUserAgent used to use LWP::Protocol::http10.pm and https10.pm, but they got replaced by http.pm and https.pm (without 10). This patch removes the *10.pm dependency.
